### PR TITLE
Implement working music playback service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,10 +12,6 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Music">
-        <service
-            android:name=".MyService"
-            android:enabled="true"
-            android:exported="true"></service>
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/example/music/MainActivity.kt
+++ b/app/src/main/java/com/example/music/MainActivity.kt
@@ -44,9 +44,9 @@ class MainActivity : AppCompatActivity(), MusicPlayerContract.View {
     }
 
     override fun updateNotification(song: Song, isPlaying: Boolean) {
-//        val intent = Intent(this, MusicService::class.java)
-//        intent.action = if (isPlaying) MusicService.ACTION_PLAY else MusicService.ACTION_PAUSE
-//        startService(intent)
+        val intent = Intent(this, MusicService::class.java)
+        intent.action = if (isPlaying) MusicService.ACTION_PLAY else MusicService.ACTION_PAUSE
+        startService(intent)
     }
 
     override fun bindEvents(presenter: MusicPlayerContract.Presenter) {

--- a/app/src/main/java/com/example/music/MusicService.kt
+++ b/app/src/main/java/com/example/music/MusicService.kt
@@ -2,11 +2,12 @@ package com.example.music
 
 import android.app.Service
 import android.content.Intent
+import android.media.MediaPlayer
 import android.os.IBinder
 
 class MusicService : Service() {
     private lateinit var model: MusicPlayerModel
-    private lateinit var presenter: MusicPlayerContract.Presenter
+    private var mediaPlayer: MediaPlayer? = null
     override fun onCreate() {
         super.onCreate()
         model = MusicList(this)
@@ -14,10 +15,37 @@ class MusicService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
-            ACTION_PLAY -> model.getCurrentSong()?.let { model.play(it); notify(it, true) }
-            ACTION_PAUSE -> model.getCurrentSong()?.let { model.pause(); notify(it, false) }
-            ACTION_NEXT -> { model.next(); model.getCurrentSong()?.let { notify(it, true) } }
-            ACTION_PREV -> { model.previous(); model.getCurrentSong()?.let { notify(it, true) } }
+            ACTION_PLAY -> {
+                val song = model.getCurrentSong() ?: return START_NOT_STICKY
+                if (mediaPlayer == null) {
+                    mediaPlayer = MediaPlayer.create(this, song.resourceId)
+                }
+                mediaPlayer?.start()
+                model.play(song)
+                notify(song, true)
+            }
+            ACTION_PAUSE -> {
+                mediaPlayer?.pause()
+                model.getCurrentSong()?.let { notify(it, false) }
+            }
+            ACTION_NEXT -> {
+                model.next()
+                model.getCurrentSong()?.let {
+                    mediaPlayer?.reset()
+                    mediaPlayer = MediaPlayer.create(this, it.resourceId)
+                    mediaPlayer?.start()
+                    notify(it, true)
+                }
+            }
+            ACTION_PREV -> {
+                model.previous()
+                model.getCurrentSong()?.let {
+                    mediaPlayer?.reset()
+                    mediaPlayer = MediaPlayer.create(this, it.resourceId)
+                    mediaPlayer?.start()
+                    notify(it, true)
+                }
+            }
         }
         return START_STICKY
     }
@@ -28,6 +56,12 @@ class MusicService : Service() {
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        super.onDestroy()
+        mediaPlayer?.release()
+        mediaPlayer = null
+    }
 
     companion object {
         const val ACTION_PLAY = "ACTION_PLAY"

--- a/app/src/main/java/com/example/music/NotificationHelper.kt
+++ b/app/src/main/java/com/example/music/NotificationHelper.kt
@@ -9,35 +9,35 @@ import androidx.core.app.NotificationCompat
 
 object NotificationHelper {
     fun createNotification(context: Context, song: Song, isPlaying: Boolean): Notification {
-//        val playIntent = Intent(context, MusicService::class.java).apply {
-//            action = if (isPlaying) MusicService.ACTION_PAUSE else MusicService.ACTION_PLAY
-//        }
-//        val playPendingIntent = PendingIntent.getService(context, 0, playIntent, PendingIntent.FLAG_IMMUTABLE)
-//
-//        val nextIntent = Intent(context, MusicService::class.java).apply { action = MusicService.ACTION_NEXT }
-//        val nextPendingIntent = PendingIntent.getService(context, 1, nextIntent, PendingIntent.FLAG_IMMUTABLE)
-//
-//        val prevIntent = Intent(context, MusicService::class.java).apply { action = MusicService.ACTION_PREV }
-//        val prevPendingIntent = PendingIntent.getService(context, 2, prevIntent, PendingIntent.FLAG_IMMUTABLE)
+        val playIntent = Intent(context, MusicService::class.java).apply {
+            action = if (isPlaying) MusicService.ACTION_PAUSE else MusicService.ACTION_PLAY
+        }
+        val playPendingIntent = PendingIntent.getService(context, 0, playIntent, PendingIntent.FLAG_IMMUTABLE)
+
+        val nextIntent = Intent(context, MusicService::class.java).apply { action = MusicService.ACTION_NEXT }
+        val nextPendingIntent = PendingIntent.getService(context, 1, nextIntent, PendingIntent.FLAG_IMMUTABLE)
+
+        val prevIntent = Intent(context, MusicService::class.java).apply { action = MusicService.ACTION_PREV }
+        val prevPendingIntent = PendingIntent.getService(context, 2, prevIntent, PendingIntent.FLAG_IMMUTABLE)
 
         val builder = NotificationCompat.Builder(context, "music_channel")
             .setContentTitle(song.title)
             .setContentText(song.artist)
             .setSmallIcon(R.drawable.ic_music)
-            //.setLargeIcon(BitmapFactory.decodeResource(context.resources, song.imageRes))
-//            .addAction(R.drawable.ic_prev, "Prev", prevPendingIntent)
-//            .addAction(
-//                if (isPlaying) R.drawable.ic_pause else R.drawable.ic_play,
-//                if (isPlaying) "Pause" else "Play",
-//                playPendingIntent
-//            )
-//            .addAction(R.drawable.ic_next, "Next", nextPendingIntent)
-//            .setStyle(
-//                androidx.media.app.NotificationCompat.MediaStyle()
-//                    .setShowActionsInCompactView(0, 1, 2)
-//            )
-//            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-//            .setOnlyAlertOnce(true)
+            .setLargeIcon(BitmapFactory.decodeResource(context.resources, song.imageRes))
+            .addAction(R.drawable.ic_prev, "Prev", prevPendingIntent)
+            .addAction(
+                if (isPlaying) R.drawable.ic_pause else R.drawable.ic_play,
+                if (isPlaying) "Pause" else "Play",
+                playPendingIntent
+            )
+            .addAction(R.drawable.ic_next, "Next", nextPendingIntent)
+            .setStyle(
+                androidx.media.app.NotificationCompat.MediaStyle()
+                    .setShowActionsInCompactView(0, 1, 2)
+            )
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setOnlyAlertOnce(true)
 
         return builder.build()
     }


### PR DESCRIPTION
## Summary
- implement `MusicService` with `MediaPlayer` to handle playback actions
- build rich notification in `NotificationHelper` with play/pause/next/prev
- start service from `MainActivity` to control playback
- clean up manifest

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6880c07dc3b88332ad39aae84b063368